### PR TITLE
update url for bc project

### DIFF
--- a/ports/core/bc/Pkgfile
+++ b/ports/core/bc/Pkgfile
@@ -6,7 +6,7 @@
 name=bc
 version=1.07.1
 release=1
-source=(http://ftpmirror.gnu.org/gnu/$name/$name-$version.tar.gz)
+source=(https://ftpmirror.gnu.org/gnu/$name/$name-$version.tar.gz)
 
 build() { 
     cd $name-$version


### PR DESCRIPTION
We cannot download the bc project via HTTP protocol anymore:

https://github.com/SVF-tools/Test-Suite/actions/runs/6876903248/job/18704539406#step:5:1640

Not sure about other projects. I'll update the Pkgfile if I find any other outdated URL :)